### PR TITLE
Individual article display functionality

### DIFF
--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -12,6 +12,7 @@ const  App = () => {
   const [allArticles, setAllArticles] = useState([])
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('')
+  // const [singleArticle, setSingleArticle] = useState({})
 
   useEffect(() => {
     getArticles()
@@ -21,6 +22,11 @@ const  App = () => {
       })
       .catch(error => setError(error) )
   }, []);
+
+  // const determineSingleArticle = (id) => {
+  //   const detailedArticle = allArticles.find(article => article.id === id)
+  //   setSingleArticle(detailedArticle)
+  // }
 
   console.log('all articles', allArticles)
 
@@ -40,7 +46,7 @@ const  App = () => {
         <NavBar/>
         <Routes>
           <Route path="/" element={<ArticlesContainer allArticles={allArticles}/>} />
-          <Route path="article/:id" element={<SingleArticle/>} />
+          <Route path="article/:id" element={<SingleArticle allArticles={allArticles}/>} />
           <Route path="*" element={<Error />} />
         </Routes>
       </>

--- a/src/Components/ArticleCard.js
+++ b/src/Components/ArticleCard.js
@@ -1,12 +1,19 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import '../Styling/ArticleCard.scss'
 
 const ArticleCard = ({ id, title, photo }) => {
+  const linkStyle = {
+    textDecoration: 'none',
+    color: 'black'
+  };
 
   return (
     <div className='article-card'>
-      <h2>{title}</h2>
-      <img className='thumbnail-pic' src={photo} alt={`Photo for article: ${title}`}/>
+      <Link style={linkStyle} to={`article/${id}`}>
+        <h2>{title}</h2>
+        <img className='thumbnail-pic' src={photo} alt={`Photo for article: ${title}`}/>
+      </Link>
     </div>
   )
 }

--- a/src/Components/SingleArticle.js
+++ b/src/Components/SingleArticle.js
@@ -1,7 +1,35 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
 
-const SingleArticle = () => {
+const SingleArticle = ({ allArticles }) => {
+  const [singleArticle, setSingleArticle] = useState({})
+  
+  let { id } = useParams();
 
+  useEffect(() => {
+    const detailedArticle = allArticles.find(article => {
+      return article.id === parseInt(id)
+    })
+    console.log('detailed article', detailedArticle)
+    setSingleArticle(detailedArticle)
+  }, [])
+
+  console.log('singleArticle', singleArticle)
+
+  return (
+    <section>
+      <div className='article-image'>
+        <img className='picture' src={singleArticle.media} alt={`Photo for article: ${singleArticle.title}`} />
+      </div>
+      <div className='article-info'>
+        <h2>{singleArticle.title}</h2>
+        <p>{singleArticle.byline}</p>
+        <p>Section: {singleArticle.section}</p>
+        <p>{singleArticle.abstract}</p>
+        <a href={singleArticle.url}>Read the Full Article</a>
+      </div>
+    </section>
+  )
 }
 
 export default SingleArticle


### PR DESCRIPTION
## 1. What changed?
SingleArticle component now has functionality - user can see more info about one specific article. User can do this by either typing in the direct url (not that they'd guess it because it's based on a long id number) or, more likely, by selecting the article from the home page.

## 2. Why is this change necessary?
I needed to have this more detailed view; I needed it to have its own route.

## 3. What changed technically?
I went back and forth on where to put the logic for this. Did I want to have the method for determining the single article live in the app or in the SingleApp component itself. I went back and forth and decided on itself. Got to implement some React hooks: useParams and useEffect

## 4. How do we test it?
Open the application. On the home view, select an article and be routed to a new view with more detailed information about that specific article. 
