### PR TITLE
Fix routing bug for wrong url

### DIFF
--- a/src/Components/SearchBar.js
+++ b/src/Components/SearchBar.js
@@ -20,7 +20,6 @@ const SearchBar = ({ searchArticles }) => {
           searchArticles(searchInput);
           clearInput();
           navigate('search-results')
-
           }
         }
       >

--- a/src/Components/SingleArticle.js
+++ b/src/Components/SingleArticle.js
@@ -1,19 +1,23 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 
 const SingleArticle = ({ allArticles }) => {
   const [singleArticle, setSingleArticle] = useState({})
+  const navigate = useNavigate()
   let { id } = useParams();
   console.log('singlearticleid', id)
+  console.log('id length', id.length)
 
   useEffect(() => {
+    if (id.length < 15) {
+      navigate(`/*`)
+    } else {
     const detailedArticle = allArticles.find(article => {
       return article.id === parseInt(id)
     })
     setSingleArticle(detailedArticle)
+    }
   }, [allArticles, id])
-
-  console.log('singleArticle', singleArticle)
 
   return (
     <section className='single-article'>


### PR DESCRIPTION
## 1. What changed?
Added a condition inside the useEffect of the Single Article component to route to the error page if a user entered a bad address rather than the page rendering nothing.

## 2. Why is this change necessary?
Gotta squish the bug. I was playing around with the url and manually typing in things to make sure it would route to the error page as expected. It did not- if the id was cut short, nothing would display (because there was no id to match to know what to display)

## 3. How do we test it?
Go to individual article and then mess around with the id at the top, delete some numbers and see that it goes to the Error page.