### PR TITLE
Fix navbar display by showing search bar or home link when appropriate

### DIFF
--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -46,8 +46,9 @@ const  App = () => {
         <NavBar searchArticles={searchArticles}/>
         <Routes>
           <Route path='/' element={<ArticlesContainer allArticles={allArticles}/>} />
-          <Route path='search-results' element={<SearchResultsContainer searchResults={searchResults}/>}/>
           <Route path='article/:id' element={<SingleArticle allArticles={allArticles}/>} />
+          <Route path='search-results' element={<SearchResultsContainer searchResults={searchResults}/>}/>
+          <Route path='search-results/article/:id' element={<SingleArticle allArticles={allArticles} />} />
           <Route path='*' element={<Error />} />
         </Routes>
       </>

--- a/src/Components/NavBar.js
+++ b/src/Components/NavBar.js
@@ -7,7 +7,7 @@ const NavBar = ({ searchArticles }) => {
   let { pathname } = useLocation();
   let navLink;
   let searchBar;
-  let id = parseInt(pathname.slice(9))
+  let id = parseInt(pathname.slice(-15))
 
   const linkStyleOne = {
     textDecoration: 'none',
@@ -17,12 +17,11 @@ const NavBar = ({ searchArticles }) => {
   };
 
   const linkStyleTwo = {
-    // textDecoration: 'none',
     color: 'white',
     fontSize: '1.5em',
   };
 
-  if (pathname === `/article/${id}`) {
+  if (pathname === `/article/${id}` || pathname === `/search-results/article/${id}`) {
     navLink = <Link className="nav-link" style={linkStyleTwo} to='/'>Back to Home</Link>;
     searchBar = null;
   } else {

--- a/src/Components/SingleArticle.js
+++ b/src/Components/SingleArticle.js
@@ -5,11 +5,9 @@ const SingleArticle = ({ allArticles }) => {
   const [singleArticle, setSingleArticle] = useState({})
   const navigate = useNavigate()
   let { id } = useParams();
-  console.log('singlearticleid', id)
-  console.log('id length', id.length)
 
   useEffect(() => {
-    if (id.length < 15) {
+    if (id.length !== 15) {
       navigate(`/*`)
     } else {
     const detailedArticle = allArticles.find(article => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,7 @@ const cleanArticles = (articleInfo) => {
       published_date: article.published_date,
     }
   })
-  console.log('clean', cleanData)
+
   return cleanData
 }
 


### PR DESCRIPTION
## 1. What changed?
Minor bug fix: the search bar was displaying in the nav bar when it should've been a link redirection a user to the home page.

## 2. Why is this change necessary?
I want to make the UI as intuitive as possible. While everything WORKED just fine, I wanted the app to be congruent and have the kind of flow that a user would expect. 

## 3. How do we test it?
Open the application, select an article - notice that the search bar has been 'replaced' with a Back to Home link.
Go home, then make a search. Upon hitting enter, the search bar is still there - can continue to make searches if you so wish. Click into an article and the search bar has been replaced with Back to Home link again. 
