### PR TITLE
Fix return on cleanArticles function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,6 @@ const cleanArticles = (articleInfo) => {
     if (article.media.length > 0 && article.title) {
       return article
     }
-    return filteredData
   })
 
   const cleanData = filteredData.map(article => {
@@ -27,7 +26,6 @@ const cleanArticles = (articleInfo) => {
       published_date: article.published_date,
     }
   })
-
   return cleanData
 }
 


### PR DESCRIPTION
## 1. What changed?
cleanArticles had an extra unnecessary return statement. Why this wasn't breaking the past few days but was breaking today, I'll never know. Deleted that return statement and everything populates as it should.

## 2. Why is this change necessary?
This bug was breaking the app- articles were not loading to the page, the information wasn't being cleaned correctly and consequently an error was being caught.

## 3. How do we test it?
npm start
All articles should load to the page correctly